### PR TITLE
PLATOPS-1924 Fixed handling of missing privacy fingerprint.

### DIFF
--- a/app/uk/gov/hmrc/leakdetection/FileAndDirectoryUtils.scala
+++ b/app/uk/gov/hmrc/leakdetection/FileAndDirectoryUtils.scala
@@ -1,0 +1,33 @@
+package uk.gov.hmrc.leakdetection
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.filefilter.{FileFileFilter, TrueFileFilter}
+import scala.collection.JavaConverters.collectionAsScalaIterableConverter
+
+object FileAndDirectoryUtils {
+  def getFiles(explodedZipDir: File): Iterable[File] =
+    FileUtils
+      .listFilesAndDirs(
+        explodedZipDir,
+        FileFileFilter.FILE,
+        TrueFileFilter.INSTANCE
+      )
+      .asScala
+
+  def getFileContents(file: File): String =
+    FileUtils.readFileToString(file, StandardCharsets.UTF_8)
+
+  def getFilePathRelativeToProjectRoot(explodedZipDir: File, file: File): String = {
+    val strippedTmpDir   = file.getAbsolutePath.stripPrefix(explodedZipDir.getAbsolutePath)
+    val strippedRepoName = strippedTmpDir.stripPrefix(File.separator + getSubdirName(explodedZipDir).getName)
+
+    strippedRepoName
+  }
+
+  def getSubdirName(parentDir: File): File =
+    parentDir.listFiles().filter(_.isDirectory).head
+
+}

--- a/app/uk/gov/hmrc/leakdetection/FileAndDirectoryUtils.scala
+++ b/app/uk/gov/hmrc/leakdetection/FileAndDirectoryUtils.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.leakdetection
 
 import java.io.File
@@ -27,7 +43,12 @@ object FileAndDirectoryUtils {
     strippedRepoName
   }
 
-  def getSubdirName(parentDir: File): File =
-    parentDir.listFiles().filter(_.isDirectory).head
+  def getSubdirName(parentDir: File): File = {
+    Option(parentDir.listFiles())
+      .toList
+      .flatten
+      .find(_.isDirectory)
+      .getOrElse(throw new RuntimeException(s"[$parentDir] directory does not exist is empty"))
+  }
 
 }

--- a/app/uk/gov/hmrc/leakdetection/scanner/RegexMatchingEngine.scala
+++ b/app/uk/gov/hmrc/leakdetection/scanner/RegexMatchingEngine.scala
@@ -17,21 +17,19 @@
 package uk.gov.hmrc.leakdetection.scanner
 
 import java.io.File
-import java.nio.charset.{CodingErrorAction, StandardCharsets}
+import java.nio.charset.CodingErrorAction
 
-import org.apache.commons.io.FileUtils
-import org.apache.commons.io.filefilter.{FileFileFilter, TrueFileFilter}
+import uk.gov.hmrc.leakdetection.FileAndDirectoryUtils
 import uk.gov.hmrc.leakdetection.config.Rule
 import uk.gov.hmrc.leakdetection.services.RulesExemptionParser
 
-import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 import scala.io.{Codec, Source}
 
 case class Result(filePath: String, scanResults: MatchedResult)
 
 class RegexMatchingEngine(rules: List[Rule], maxLineLength: Int) {
 
-  import FileAndDirectoryUtils._
+  import uk.gov.hmrc.leakdetection.FileAndDirectoryUtils._
 
   val fileContentScanners = createFileContentScanners(rules)
   val fileNameScanners    = createFileNameScanners(rules)
@@ -101,27 +99,4 @@ class RegexMatchingEngine(rules: List[Rule], maxLineLength: Int) {
 
 }
 
-object FileAndDirectoryUtils {
-  def getFiles(explodedZipDir: File): Iterable[File] =
-    FileUtils
-      .listFilesAndDirs(
-        explodedZipDir,
-        FileFileFilter.FILE,
-        TrueFileFilter.INSTANCE
-      )
-      .asScala
 
-  def getFileContents(file: File): String =
-    FileUtils.readFileToString(file, StandardCharsets.UTF_8)
-
-  def getFilePathRelativeToProjectRoot(explodedZipDir: File, file: File): String = {
-    val strippedTmpDir   = file.getAbsolutePath.stripPrefix(explodedZipDir.getAbsolutePath)
-    val strippedRepoName = strippedTmpDir.stripPrefix(File.separator + getSubdirName(explodedZipDir).getName)
-
-    strippedRepoName
-  }
-
-  def getSubdirName(parentDir: File): File =
-    parentDir.listFiles().filter(_.isDirectory).head
-
-}

--- a/app/uk/gov/hmrc/leakdetection/services/RepoVisiblityChecker.scala
+++ b/app/uk/gov/hmrc/leakdetection/services/RepoVisiblityChecker.scala
@@ -20,6 +20,7 @@ import java.{util => ju}
 
 import org.yaml.snakeyaml.Yaml
 import play.api.Logger
+import uk.gov.hmrc.leakdetection.FileAndDirectoryUtils
 
 import scala.collection.JavaConverters._
 import scala.io.Source
@@ -32,7 +33,10 @@ class RepoVisiblityChecker {
 
   def hasCorrectVisibilityDefined(dir: File, isPrivate: Boolean): Boolean =
     try {
-      val repositoryYaml: File = new File(dir.getAbsolutePath.concat("/repository.yaml"))
+
+      val projectRoot = FileAndDirectoryUtils.getSubdirName(dir)
+
+      val repositoryYaml: File = new File(projectRoot.getAbsolutePath.concat("/repository.yaml"))
 
       if (!repositoryYaml.exists()) {
         Logger.warn(s"$repositoryYaml file not found")

--- a/app/uk/gov/hmrc/leakdetection/services/ScanningService.scala
+++ b/app/uk/gov/hmrc/leakdetection/services/ScanningService.scala
@@ -97,12 +97,16 @@ class ScanningService @Inject()(
     author: String,
     dir: File,
     isPrivate: Boolean)(implicit hc: HeaderCarrier): Future[Unit] =
-    if (!repoVisibilityChecker.hasCorrectVisibilityDefined(dir, isPrivate) && branchName == "master") {
-      Logger.warn(
-        s"Incorrect configuration for repo $repoName on $branchName branch! File path: ${dir.getAbsolutePath}. Sending alert")
-      alertingService.alertAboutRepoVisibility(repoName, author)
+    if (branchName == "master") {
+      if (!repoVisibilityChecker.hasCorrectVisibilityDefined(dir, isPrivate)) {
+        Logger.warn(
+          s"Incorrect configuration for repo $repoName on $branchName branch! File path: ${dir.getAbsolutePath}. Sending alert")
+        alertingService.alertAboutRepoVisibility(repoName, author)
+      } else {
+        Logger.info(s"repo: $repoName, branch: $branchName, dir: ${dir.getAbsolutePath}. No action needed")
+        Future.successful(())
+      }
     } else {
-      Logger.info(s"repo: $repoName, branch: $branchName, dir: ${dir.getAbsolutePath}. No action needed")
       Future.successful(())
     }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -176,7 +176,7 @@ alerts {
             username = leak-detection
             password = development-only
         }
-        repoVisibilityMessageText = "Action Required! Repository `{repo}` doesn't contain repository.yaml file with the correct repoVisibility. You can read more details about why this is required here: BLOG POST LINK HERE"
+        repoVisibilityMessageText = "Action Required! Repository `{repo}` doesn't contain repository.yaml file with the correct repoVisibility. You can read more details about why this is required here: https://confluence.tools.tax.service.gov.uk/x/k_8TCQ"
         enabledForRepoVisibility = false
     }
 }

--- a/test/uk/gov/hmrc/leakdetection/FileAndDirectoryUtilsSpec.scala
+++ b/test/uk/gov/hmrc/leakdetection/FileAndDirectoryUtilsSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.leakdetection.scanner
+package uk.gov.hmrc.leakdetection
 
 import ammonite.ops.{Path, mkdir, tmp, write}
 import org.scalatest.{Matchers, WordSpec}

--- a/test/uk/gov/hmrc/leakdetection/services/RepoVisiblityCheckerSpec.scala
+++ b/test/uk/gov/hmrc/leakdetection/services/RepoVisiblityCheckerSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.leakdetection.services
 import java.nio.file.Files
 
-import ammonite.ops.{Path, tmp, write}
+import ammonite.ops.{Path, mkdir, tmp, write}
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Random
@@ -37,7 +37,9 @@ class RepoVisiblityCheckerSpec extends WordSpec with Matchers {
     "confirm if repoVisibility has correct value for a public repository" in {
       val yamlFileContents = "repoVisibility: public_0C3F0CE3E6E6448FAD341E7BFA50FCD333E06A20CFF05FCACE61154DDBBADF71"
       val dir: Path        = tmp.dir()
-      write(dir / "repository.yaml", yamlFileContents)
+      val subDir: Path     = dir / "test"
+      mkdir(subDir)
+      write(subDir / "repository.yaml", yamlFileContents)
 
       val checker = new RepoVisiblityChecker()
 
@@ -47,7 +49,9 @@ class RepoVisiblityCheckerSpec extends WordSpec with Matchers {
     "confirm if repoVisibility has correct value for a private repository" in {
       val yamlFileContents = "repoVisibility: private_12E5349CFB8BBA30AF464C24760B70343C0EAE9E9BD99156345DD0852C2E0F6F"
       val dir: Path        = tmp.dir()
-      write(dir / "repository.yaml", yamlFileContents)
+      val subDir: Path     = dir / "test"
+      mkdir(subDir)
+      write(subDir / "repository.yaml", yamlFileContents)
 
       val checker = new RepoVisiblityChecker()
 
@@ -57,7 +61,9 @@ class RepoVisiblityCheckerSpec extends WordSpec with Matchers {
     "return false if the file doesn't have the repoVisibility key" in {
       val yamlFileContents = "foo: bar"
       val dir: Path        = tmp.dir()
-      write(dir / "repository.yaml", yamlFileContents)
+      val subDir: Path     = dir / "test"
+      mkdir(subDir)
+      write(subDir / "repository.yaml", yamlFileContents)
 
       val checker = new RepoVisiblityChecker()
 
@@ -67,7 +73,9 @@ class RepoVisiblityCheckerSpec extends WordSpec with Matchers {
     "return false if the repoVisibility key doesn't have a string value" in {
       val yamlFileContents = "repoVisibility: 1"
       val dir: Path        = tmp.dir()
-      write(dir / "repository.yaml", yamlFileContents)
+      val subDir: Path     = dir / "test"
+      mkdir(subDir)
+      write(subDir / "repository.yaml", yamlFileContents)
 
       val checker = new RepoVisiblityChecker()
 

--- a/test/uk/gov/hmrc/leakdetection/services/ScanningServiceSpec.scala
+++ b/test/uk/gov/hmrc/leakdetection/services/ScanningServiceSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.leakdetection.config._
 import uk.gov.hmrc.leakdetection.model.{PayloadDetails, Report, ReportId, ReportLine}
 import uk.gov.hmrc.leakdetection.persistence.GithubRequestsQueueRepository
-import uk.gov.hmrc.leakdetection.scanner.FileAndDirectoryUtils._
+import uk.gov.hmrc.leakdetection.FileAndDirectoryUtils._
 import uk.gov.hmrc.leakdetection.scanner.Match
 import uk.gov.hmrc.leakdetection.services.ArtifactService.ExplodedZip
 import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}


### PR DESCRIPTION
Existing code had couple of bugs:
1) zip files returned by github contain subdirectory with name of repository, and repository.yaml is there,
2) some steps of processing the repo happen asynchronously and we delete unzipped file before asynchronous process ends.