### PR TITLE
Increase tfstate alert priority from low to medium

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -372,14 +372,14 @@ allRules {
       scope = fileName
       regex = """\A.*.tfstate.*\z"""
       description = "Terrafrom state file https://www.terraform.io/docs/language/state/sensitive-data.html"
-      priority = "low"
+      priority = "medium"
     },
     {
       id = "tfstate_2"
       scope = fileName
       regex = """\A*.tfstate\z"""
       description = "Terrafrom state file https://www.terraform.io/docs/language/state/sensitive-data.html"
-      priority = "low"
+      priority = "medium"
     },
     {
       id = "message_delivery_group_key"


### PR DESCRIPTION
We have been in discussions with ED and Dsysms around the fact that we know some teams such as DDCOPS have DB passwords in there TF state (a side effect of using the aws_rds_instance resource)

Following this, there was an agreement to discourage checking in state to git in the next MDTP security principles doc version

Given that I think It would be prudent to up tfstate alerts from low to medium